### PR TITLE
Fix verticaldrift modules for v10

### DIFF
--- a/protoduneana/verticaldrift/CMakeLists.txt
+++ b/protoduneana/verticaldrift/CMakeLists.txt
@@ -1,2 +1,2 @@
-#add_subdirectory(checks)
-#add_subdirectory(singlehit)
+add_subdirectory(checks)
+add_subdirectory(singlehit)

--- a/protoduneana/verticaldrift/checks/ColdboxTrackStudy_module.cc
+++ b/protoduneana/verticaldrift/checks/ColdboxTrackStudy_module.cc
@@ -22,6 +22,7 @@
 
 // LarSoft
 #include "larcore/CoreUtils/ServiceUtil.h"
+#include "larcore/Geometry/WireReadout.h"
 #include "larcore/Geometry/Geometry.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/ServicePack.h" 
@@ -224,6 +225,7 @@ private:
   
   // colbox-VD geometry
   const geo::Geometry* fCbvdGeom ;
+  const geo::WireReadoutGeom* fWireReadoutGeom;
   unsigned int         fNPlanes;
   float                fCbvdXmin; 
   float                fCbvdXmax; 
@@ -390,6 +392,7 @@ pdvdana::ColdboxTrackStudy::ColdboxTrackStudy(fhicl::ParameterSet const& p)
 {
   // Calling detector geometry product 
   fCbvdGeom = &*art::ServiceHandle<geo::Geometry>();
+  fWireReadoutGeom = &art::ServiceHandle<geo::WireReadout>()->Get();
 }
 
 bool pdvdana::ColdboxTrackStudy::CheckIfTrackIsThroughGoing(float trackStartVec[3], float trackEndVec[3])
@@ -898,7 +901,7 @@ void pdvdana::ColdboxTrackStudy::beginJob()
   fTrackTree = tfs->make<TTree>("trackTree","Store information about tracks" );
 
   // Get the number of anode planes to resize some vectors
-  fNPlanes = fCbvdGeom -> Nplanes();
+  fNPlanes = fWireReadoutGeom->Nplanes();
   if( fNPlanes != 3) std::cout << "!!! Warning! Number of planes found is: " << fNPlanes << std::endl ;
 
   //////////////////////////////////////////////////////

--- a/protoduneana/verticaldrift/singlehit/SingleHit_module.cc
+++ b/protoduneana/verticaldrift/singlehit/SingleHit_module.cc
@@ -26,6 +26,7 @@
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/ServicePack.h" 
 #include "larcore/Geometry/WireReadout.h"
+#include "larcore/Geometry/Geometry.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Track.h"
 #include "lardataobj/RecoBase/TrackHitMeta.h"
@@ -383,8 +384,8 @@ pdvdana::SingleHit::SingleHit(fhicl::ParameterSet const& p)
     fG4Label(p.get<std::string>("G4Label","largeant")),
     fRDTLabel(p.get<std::string>("RDTLabel","tpcrawdecoder:daq")),
 
-    LogLevel(p.get<int>("LogLevel")),
     fMultiplicity(p.get<int>("HitMultiplicity")),
+    LogLevel(p.get<int>("LogLevel")),
    
     fRadiusInt(p.get<float>("RadiusInt")),
     fRadiusExt(p.get<float>("RadiusExt")),
@@ -1530,7 +1531,7 @@ void pdvdana::SingleHit::GetListOfCrossingChannel(  float Ymin , float Ymax , fl
   bool drap;
 
   double y = -999. , z = -999.;
-  auto const wcol = fWireReadout.WireEndPoints(WireCol);
+  auto const [wcolstart, wcolend] = fWireReadout.WireEndPoints(WireCol);
 
   std::list<int>::iterator ch1  = ChInd1.begin();
   for (auto const elementInd1 : WireInd1)
@@ -1538,8 +1539,8 @@ void pdvdana::SingleHit::GetListOfCrossingChannel(  float Ymin , float Ymax , fl
     if (WireCol.TPC != elementInd1.TPC )
     {
       
-      auto const wind1 = fWireReadout.WireEndPoints(elementInd1);
-      bool flag = IntersectOutsideOfTPC( Ymin , Ymax , Zmin ,Zmax , wind1.start().Y() , wind1.start().Z() , wind1.end().Y() , wind1.end().Z() , wcol.start().Y() , wcol.start().Z() , wcol.end().Y() , wcol.end().Z() , y , z);
+      auto const [wind1start, wind1end] = fWireReadout.WireEndPoints(elementInd1);
+      bool flag = IntersectOutsideOfTPC( Ymin , Ymax , Zmin ,Zmax , wind1start.Y() , wind1start.Z() , wind1end.Y() , wind1end.Z() , wcolstart.Y() , wcolstart.Z() , wcolend.Y() , wcolend.Z() , y , z);
       if (flag)
       {
 	YInd1.push_back(y);
@@ -1565,8 +1566,8 @@ void pdvdana::SingleHit::GetListOfCrossingChannel(  float Ymin , float Ymax , fl
   { 
     if (WireCol.TPC != elementInd2.TPC )
     { 
-      auto const wind2 = fWireReadout.WireEndPoints(elementInd2);
-      bool flag = IntersectOutsideOfTPC( Ymin , Ymax , Zmin ,Zmax , wind2.start().Y() , wind2.start().Z() , wind2.end().Y() , wind2.end().Z() , wcol.start().Y() , wcol.start().Z() , wcol.end().Y() , wcol.end().Z() , y , z);
+      auto const [wind2start, wind2end] = fWireReadout.WireEndPoints(elementInd2);
+      bool flag = IntersectOutsideOfTPC( Ymin , Ymax , Zmin ,Zmax , wind2start.Y() , wind2start.Z() , wind2end.Y() , wind2end.Z() , wcolstart.Y() , wcolstart.Z() , wcolend.Y() , wcolend.Z() , y , z);
       if (flag)
       {
         YInd2.push_back(y);


### PR DESCRIPTION
It looks as if most of the v10 refactoring work has aleady been done in protoduneana/verticaldrift.  Just a few things had to be tweaked to get the modules to compile under v10.